### PR TITLE
Literal values ​​instead of repository variables in workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
     permissions:
       contents: write
     with:
-      go-version: ${{vars.GO_VERSION}}
-      k6-version: ${{vars.K6_VERSION}}
-      xk6-version: ${{vars.XK6_VERSION}}
-      os: ${{vars.OS}}
-      arch: ${{vars.ARCH}}
+      go-version: "1.24.x"
+      os: '["linux", "windows", "darwin"]'
+      arch: '["amd64", "arm64"]'
+      k6-version: "v1.2.3"
+      xk6-version: "1.1.4"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,9 +18,9 @@ jobs:
       pages: write
       id-token: write
     with:
-      go-version: ${{vars.GO_VERSION}}
-      go-versions: ${{vars.GO_VERSIONS}}
-      golangci-lint-version: ${{vars.GOLANGCI_LINT_VERSION}}
-      platforms: ${{vars.PLATFORMS}}
-      k6-versions: ${{vars.K6_VERSIONS}}
-      xk6-version: ${{vars.XK6_VERSION}}
+      go-version: "1.24.x"
+      go-versions: '["1.24.x","1.25.x"]'
+      golangci-lint-version: "v2.1.6"
+      platforms: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      k6-versions: '["v1.2.3", "v1.0.0"]'
+      xk6-version: "1.1.4"


### PR DESCRIPTION
In case of external pull requests, repository variables are not available, so the workflows would fail to run. Therefore, instead of using repository variables, literal values ​​are used in the workflow files.
