### PR TITLE
Fix Renovate configuration preset reference

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>renovate-k6-extension-preset.json"],
+  "extends": ["renovate-k6-extension-preset.json"],
   "prConcurrentLimit": 20,
   "packageRules": [
     {


### PR DESCRIPTION
Fixes the Renovate configuration error by correcting the preset reference path.

## Problem

Renovate is reporting a configuration error because it cannot resolve the preset reference in `renovate.json`. The current configuration uses the `local>` prefix, which is intended for cross-repository references within the same organization. Since the target preset file `renovate-k6-extension-preset.json` is located within the same repository, this causes a lookup failure and blocks Renovate from creating PRs.

**Current problematic configuration:**
```json
"extends": ["local>renovate-k6-extension-preset.json"]
```

## Solution

Changed the preset reference to use a direct internal path reference by removing the `local>` prefix. This is the standard way to reference local files in Renovate when they are in the same repository.

**Fixed configuration:**
```json
"extends": ["renovate-k6-extension-preset.json"]
```

This allows Renovate to properly locate and load the preset configuration file from the repository root.

Fixes #93