### PR TITLE
build: pin go toolchain to latest patch version for security

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,7 @@
     "ghcr.io/szkiba/devcontainer-features/bats:1": { "version": "1.11.1" },
     "ghcr.io/szkiba/devcontainer-features/cdo:1": { "version": "0.1.2" },
     "ghcr.io/szkiba/devcontainer-features/mdcode:1": { "version": "0.2.0" },
-    "ghcr.io/grafana/devcontainer-features/xk6:1": { "version": "1.1.5" }
+    "ghcr.io/grafana/devcontainer-features/xk6:1": { "version": "1.4.1" }
   },
 
   "remoteEnv": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: grafana/xk6/.github/workflows/extension-release.yml@v1.4.0
+    uses: grafana/xk6/.github/workflows/extension-release.yml@1556f094f3883e37ebff04b967fddac30681c466 # v1.4.1
     permissions:
       contents: write
     with:
@@ -17,4 +17,4 @@ jobs:
       os: '["linux", "windows", "darwin"]'
       arch: '["amd64", "arm64"]'
       k6-version: "v2.0.0-rc1"
-      xk6-version: "1.4.0"
+      xk6-version: "1.4.1"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   validate:
     name: Validate
-    uses: grafana/xk6/.github/workflows/extension-validate.yml@v1.4.0
+    uses: grafana/xk6/.github/workflows/extension-validate.yml@1556f094f3883e37ebff04b967fddac30681c466 # v1.4.1
     permissions:
       contents: read
       pages: write
@@ -23,4 +23,4 @@ jobs:
       golangci-lint-version: "v2.10.1"
       platforms: '["ubuntu-latest", "windows-latest", "macos-latest"]'
       k6-versions: '["v2.0.0-rc1"]'
-      xk6-version: "1.4.0"
+      xk6-version: "1.4.1"

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/xk6-faker
 
 go 1.25.8
 
+toolchain go1.25.10
+
 require (
 	github.com/brianvoe/gofakeit/v6 v6.28.0
 	github.com/grafana/sobek v0.0.0-20260331145705-2272ac4993ef


### PR DESCRIPTION
Pin the Go toolchain in go.mod to the latest patch version of the minor it currently targets, picking up the latest security and bugfix releases.