### PR TITLE
build: pin package manager and disable automatic lifecycle scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+ignore-scripts true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+enableScripts: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "xk6-faker",
   "version": "0.4.4",
+  "packageManager": "npm@10.9.2",
   "description": "Random fake data generator for k6",
   "repository": "github:grafana/xk6-faker",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
Disables automatic execution of npm/yarn install-time lifecycle scripts
(`preinstall`, `install`, `postinstall`, `prepare`, …) so a malicious or
compromised transitive dependency cannot run arbitrary code during
`npm install` / `yarn install`. Manually invoked scripts (`npm run …`,
`yarn …`) are unaffected — only auto-execution at install time is blocked.

Two complementary hardenings:

1. **Pin the package manager** via the `packageManager` field in
   `package.json`. With Corepack (default in Node ≥22), this determines
   which binary actually runs in this repo, preventing a stray manager
   from bypassing the config below.
   - npm repos: `"packageManager": "npm@10.9.2"`

2. **Write all three package-manager config files** at the repo root,
   regardless of which manager the repo currently uses. Defense in depth:
   each file is read only by its own tool, so writing all three costs
   nothing and guards against npm, Yarn Classic, and Yarn Berry equally.
   - `.npmrc` → `ignore-scripts=true`  (npm, also honored by Yarn Classic)
   - `.yarnrc` → `ignore-scripts true`  (Yarn Classic, explicit)
   - `.yarnrc.yml` → `enableScripts: false`  (Yarn Berry; does not read `.npmrc`)
